### PR TITLE
update npm name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "n8n-nodes-heygen-official",
+  "name": "@heygenofficial/n8n-nodes-heygen-official",
   "version": "0.1.6",
   "description": "Generate Avatar Video with HeyGen",
   "keywords": [


### PR DESCRIPTION
### TL;DR

Updated the package name to use the `@heygenofficial` namespace.

### What changed?

Changed the package name in `package.json` from `n8n-nodes-heygen-official` to `@heygenofficial/n8n-nodes-heygen-official` to properly namespace the package under the HeyGen organization.

### How to test?

1. Install the package using the new namespaced name: `npm install @heygenofficial/n8n-nodes-heygen-official`
2. Verify that the package works as expected after installation
3. Check that imports using the new package name function correctly

### Why make this change?

This change follows npm best practices by using a scoped package name under the organization's namespace. Using the `@heygenofficial` scope helps prevent naming conflicts with other packages and clearly identifies this as an official HeyGen package, improving discoverability and establishing authenticity.